### PR TITLE
Implement event endpoint

### DIFF
--- a/Hackathon/mapthing/models.py
+++ b/Hackathon/mapthing/models.py
@@ -3,6 +3,7 @@ from django.db.models.deletion import CASCADE
 from django.utils import timezone
 from django.contrib.auth.models import User
 
+
 class Event(models.Model):
     event_name = models.CharField(max_length=200)
     creator = models.ForeignKey(User, on_delete=CASCADE)
@@ -14,10 +15,28 @@ class Event(models.Model):
     min_number_people = models.IntegerField(null=True)
     max_number_people = models.IntegerField(null=True)
     public = models.BooleanField(default=True)
-    
+
     def __str__(self) -> str:
         return self.event_name
-    
+
+    def serialize(self):
+        data = {
+            'id': self.id,
+            'name': self.event_name,
+            'description': self.description,
+            'latitude': self.latitude,
+            'longitude': self.longitude,
+            'startTime': self.start_date.timestamp(),
+            'endTime': self.end_date.timestamp(),
+            'public': self.public,
+            'creator': str(self.creator.id)
+        }
+        if self.min_number_people is not None:
+            data['minPeople'] = self.min_number_people
+            data['maxPeople'] = self.max_number_people
+        return data
+
+
 class Attend(models.Model):
     attendee = models.ForeignKey(User, on_delete=CASCADE)
     associated_event = models.ForeignKey(Event, on_delete=CASCADE)

--- a/Hackathon/mapthing/urls.py
+++ b/Hackathon/mapthing/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('api/create-user/', views.create_user, name='create-user'),
     path('api/create-event/', views.create_event, name='create-event'),
-    path('api/attend-event/',views.attend_event, name='attend-event')
+    path('api/attend-event/', views.attend_event, name='attend-event'),
+    path('api/event/<str:event_id>/', views.event, name='event'),
 ]

--- a/Hackathon/mapthing/views.py
+++ b/Hackathon/mapthing/views.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.http.response import HttpResponse
 from django.shortcuts import render
 from django.http import JsonResponse, QueryDict
@@ -21,11 +23,13 @@ def create_event(request):
         description = require(event_data, 'description', str)
         latitude = require(event_data, 'latitude', float)
         longitude = require(event_data, 'longitude', float)
-        start_time = require(event_data, 'startTime', float)
-        end_time = require(event_data, 'endTime', float)
+        start_time = datetime.fromtimestamp(
+            require(event_data, 'startTime', float))
+        end_time = datetime.fromtimestamp(
+            require(event_data, 'endTime', float))
         min_people = get(event_data, 'minPeople')
         max_people = get(event_data, 'maxPeople')
-    except (KeyError, TypeError) as e:
+    except (KeyError, TypeError, ValueError) as e:
         return JsonResponse({'success': False, 'error': e.args[0]})
 
     event = Event(event_name=name,

--- a/Hackathon/mapthing/views.py
+++ b/Hackathon/mapthing/views.py
@@ -4,7 +4,7 @@ from django.http.response import HttpResponse
 from django.shortcuts import render
 from django.http import JsonResponse, QueryDict
 from django.contrib.auth.models import User
-from .models import Event,Attend
+from .models import Event, Attend
 
 from .util import get, require
 
@@ -57,6 +57,7 @@ def create_user(request):
     user = User.objects.create_user(name)
     return JsonResponse({'success': True, 'userId': user.id})
 
+
 def attend_event(request):
     if request.method != 'POST':
         return JsonResponse({'success': False, 'error': 'invalid request'})
@@ -69,11 +70,14 @@ def attend_event(request):
         if event.exists() == True:
             return JsonResponse({'success': True})
         else:
-            return JsonResponse({'success': False}) 
+            return JsonResponse({'success': False})
     except (KeyError, TypeError) as e:
-        return JsonResponse({'success': 'False, event not exists', 'error': e.args[0]})
-
-    
+        return JsonResponse({'success': False, 'error': e.args[0]})
 
 
-
+def event(request, event_id):
+    try:
+        event = Event.objects.get(pk=event_id)
+    except Event.DoesNotExist:
+        return JsonResponse({'error': 'event does not exist'})
+    return JsonResponse(event.serialize())


### PR DESCRIPTION
This PR:
- implements the `/api/event/<id>/` endpoint in the `event` view
- adds `serialize()` method to `Event` model
- changes `create_event` view to create `Event` objects using `datetime` objects instead of floats